### PR TITLE
multiple bugfixes

### DIFF
--- a/bcsc/bcsc_zinit.c
+++ b/bcsc/bcsc_zinit.c
@@ -32,8 +32,8 @@ void transpose_z_Matrix(pastix_int_t 		n,
 	if(*rowPrediction == NULL){
 		pastix_int_t* temp = (pastix_int_t*) calloc(n, sizeof(pastix_int_t));
 		MALLOC_INTERN(*rowPrediction, colptrIn[n]-1, pastix_int_t);
-		for(int i = 0; i < n; i++){
-			for(int j = colptrIn[i] - 1; j < colptrIn[i+1] - 1 ; j++){
+		for(pastix_int_t i = 0; i < n; i++){
+			for(pastix_int_t j = colptrIn[i] - 1; j < colptrIn[i+1] - 1 ; j++){
 				(*rowPrediction)[j] = temp[rowptrIn[j]-1]++;
 			}
 		}
@@ -41,8 +41,8 @@ void transpose_z_Matrix(pastix_int_t 		n,
 	}
 	
 	#pragma omp parallel for
-	for(int i = 0; i < n; i++){
-		for(int j = colptrIn[i] - 1; j < colptrIn[i+1] - 1 ; j++){
+	for(pastix_int_t i = 0; i < n; i++){
+		for(pastix_int_t j = colptrIn[i] - 1; j < colptrIn[i+1] - 1 ; j++){
 			pastix_int_t target = colptrIn[rowptrIn[j]-1]-1 + (*rowPrediction)[j];
 			valuesOut[target] = valuesIn[j];
 		}
@@ -507,7 +507,7 @@ void bcsc_zsort( pastix_bcsc_t *bcsc,
 		MALLOC_INTERN(*sorttab, bcsc->numElements, pastix_int_t);
 		
 		#pragma omp parallel for
-		for(int i = 0; i < bcsc->numElements; i++){
+		for(pastix_int_t i = 0; i < bcsc->numElements; i++){
 			(*sorttab)[i] = i;
 		}
 		
@@ -517,23 +517,23 @@ void bcsc_zsort( pastix_bcsc_t *bcsc,
 			for (itercol=0; itercol<blockcol->colnbr; itercol++)
 			{
 				/*size = blockcol->coltab[itercol+1] - blockcol->coltab[itercol];
-				for(int i = blockcol->coltab[itercol]; i < blockcol->coltab[itercol+1]; i++){
+				for(pastix_int_t i = blockcol->coltab[itercol]; i < blockcol->coltab[itercol+1]; i++){
 					printf("sortTab[%d] = %ld\n", i, (bcsc->sortTab)[i]);
 				}
 				printf("\n _______________ \n");
 				
-				for(int i = blockcol->coltab[itercol]; i < blockcol->coltab[itercol+1]; i++){
+				for(pastix_int_t i = blockcol->coltab[itercol]; i < blockcol->coltab[itercol+1]; i++){
 					printf("rows[%d] = %ld\n", i, (*rowtab)[i]);
 				}
 				printf("\n _______________ \n");
 */
 				cppSort( (*sorttab) + blockcol->coltab[itercol], (*sorttab) + blockcol->coltab[itercol+1], rowtab );
 				/*
-				for(int i = blockcol->coltab[itercol]; i < blockcol->coltab[itercol+1]; i++){
+				for(pastix_int_t i = blockcol->coltab[itercol]; i < blockcol->coltab[itercol+1]; i++){
 					printf("rows[%d] = %ld\n", i, permedRows[i]);
 				}
 				printf("\n _______________ \n");
-				for(int i = blockcol->coltab[itercol]; i < blockcol->coltab[itercol+1]; i++){
+				for(pastix_int_t i = blockcol->coltab[itercol]; i < blockcol->coltab[itercol+1]; i++){
 					printf("sortTab[%d] = %ld\n", i, (bcsc->sortTab)[i]);
 				}
 				printf("\n\n\n");
@@ -544,7 +544,7 @@ void bcsc_zsort( pastix_bcsc_t *bcsc,
 		}
 	}
     #pragma omp parallel for
-    for(int i = 0; i < bcsc->numElements; i++){
+    for(pastix_int_t i = 0; i < bcsc->numElements; i++){
 		permedValues[i] = valtab[(*sorttab)[i]];
 		permedRows[i] = rowtab[(*sorttab)[i]];
 	}
@@ -559,7 +559,7 @@ void bcsc_zsort( pastix_bcsc_t *bcsc,
     MALLOC_INTERN(inverseSorttab, bcsc->numElements, pastix_int_t);
     
     #pragma omp parallel for
-    for (int i = 0; i < bcsc->numElements; i++)  
+    for (pastix_int_t i = 0; i < bcsc->numElements; i++)  
 		inverseSorttab[(*sorttab)[i]] = i;
 		
 	free(*sorttab);

--- a/blend/simu.c
+++ b/blend/simu.c
@@ -156,7 +156,7 @@ simuInit( SimuCtrl              *simuctrl,
             timerSet(&(simuctrl->ftgttab[i].timerecv), 0.0);
             simuctrl->ftgttab[i].costsend = 0.0;
             simuctrl->ftgttab[i].costadd  = 0.0;
-            bzero(simuctrl->ftgttab[i].ftgt.infotab,FTGT_MAXINFO*sizeof(pastix_int_t));
+            memset( simuctrl->ftgttab[i].ftgt.infotab, 0, FTGT_MAXINFO * sizeof(pastix_int_t) );
             simuctrl->ftgttab[i].ftgt.infotab[FTGT_FCOLNUM] = PASTIX_INT_MAX;
             simuctrl->ftgttab[i].ftgt.infotab[FTGT_FROWNUM] = PASTIX_INT_MAX;
             simuctrl->ftgttab[i].ftgt.infotab[FTGT_CTRBNBR] = 0;

--- a/make_pastix.sh
+++ b/make_pastix.sh
@@ -4,6 +4,7 @@ if ! [[ -d build ]]; then
 fi
 cd build
 
+<<<<<<< HEAD
 INSTALLPATH="~/pastix"
 CUDADIR="/usr/lib/cuda"
 PARSECDIR="/usr/lib/parsec"

--- a/order/order_find_supernodes.c
+++ b/order/order_find_supernodes.c
@@ -56,7 +56,7 @@ compute_subtree_size(      pastix_int_t  n,
     /* TODO pas la peine d'utiliser un tas; il suffit de parcourir iperm pour assurer
      de toujours traiter un fils avant son pere */
 
-    bzero(T, sizeof(pastix_int_t)*n);
+    memset( T, 0, sizeof(pastix_int_t) * n );
 
     for(k=0;k<n;k++)
     {
@@ -168,24 +168,27 @@ compute_post_order(      pastix_int_t n,
         assert(perm[i] <  n);
     }
 
-    bzero(invp, sizeof(pastix_int_t)*n);
-    for(i=0;i<n;i++)
+    memset( invp, 0, sizeof(pastix_int_t) * n );
+    for(i=0;i<n;i++) {
         invp[perm[i]]++;
+    }
 
     k = 0;
-    for(i=0;i<n;i++)
-        if(invp[i] != 1)
-            k++;
-    if(k>0)
+    for(i=0;i<n;i++) {
+        if(invp[i] != 1) { k++; }
+    }
+    if ( k > 0 ) {
         errorPrint("Number of errors in perm vector in postorder %ld", (long)k);
+    }
     assert(k==0);
 #endif
 
     /*
      * Compute the invp vector
      */
-    for(i=0; i<n; i++)
+    for(i=0; i<n; i++) {
         invp[perm[i]] = i;
+    }
 }
 
 /**
@@ -245,7 +248,7 @@ compute_elimination_tree(      pastix_int_t n,
         jrev[i] = -1;
 
     MALLOC_INTERN(jf, n, pastix_int_t);
-    bzero(jf, sizeof(pastix_int_t)*n);
+    memset( jf, 0, sizeof(pastix_int_t) * n );
 
     for(i=0;i<n;i++)
         father[i] = -1;
@@ -394,7 +397,7 @@ pastixOrderFindSupernodes( const pastix_graph_t *graph,
         assert(invp[i] < n);
     }
 
-    bzero(S, sizeof(pastix_int_t)*n);
+    memset( S, 0 sizeof(pastix_int_t) * n );
     for(i=0;i<n;i++)
         S[perm[i]]++;
 
@@ -430,8 +433,8 @@ pastixOrderFindSupernodes( const pastix_graph_t *graph,
 
     MALLOC_INTERN(isleaf,     n, pastix_int_t);
     MALLOC_INTERN(prev_rownz, n, pastix_int_t);
-    bzero(isleaf,     sizeof(pastix_int_t)*n);
-    bzero(prev_rownz, sizeof(pastix_int_t)*n);
+    memset(isleaf,     0, sizeof(pastix_int_t) * n );
+    memset(prev_rownz, 0, sizeof(pastix_int_t) * n );
 
     for(j=0;j<n;j++)
     {
@@ -456,7 +459,7 @@ pastixOrderFindSupernodes( const pastix_graph_t *graph,
      * Compute the number of sons of each node in the elimination tree
      * The snodetab/rangtab is computed in the workspace T.
      */
-    bzero(S, sizeof(pastix_int_t)*n);
+    memset( S, 0, sizeof(pastix_int_t) * n );
     for(i=0;i<n;i++) {
         if(father[i] != i) {
             S[father[i]]++;

--- a/refinement/pastix_task_refine.c
+++ b/refinement/pastix_task_refine.c
@@ -252,7 +252,7 @@ pastix_task_refine( pastix_data_t *pastix_data,
     void* tmpBcscValues = NULL;
     double timer;
     char GPUtemp = iparm[IPARM_GPU_NBR];
-    if(getenv("PASTIX_REFINE_GPU") != NULL && *(getenv("PASTIX_REFINE_GPU")) != '1')
+    if(getenv("PASTIX_REFINE_GPU") == NULL || *(getenv("PASTIX_REFINE_GPU")) != '1')
 		iparm[IPARM_GPU_NBR] = 0;
     
     if ( (pastix_data->schur_n > 0) && (iparm[IPARM_SCHUR_SOLV_MODE] != PastixSolvModeLocal))
@@ -347,7 +347,7 @@ pastix_task_refine( pastix_data_t *pastix_data,
 			bcsc->Lvalues = bcsc->Uvalues = tmpBcscValues;
 		}
 		
-		if(getenv("PASTIX_REFINE_GPU") != NULL && *(getenv("PASTIX_REFINE_GPU")) != '1')
+		if(getenv("PASTIX_REFINE_GPU") == NULL || *(getenv("PASTIX_REFINE_GPU")) != '1')
 			iparm[IPARM_GPU_NBR] = GPUtemp;
 
 	}

--- a/refinement/z_refine_functions.c
+++ b/refinement/z_refine_functions.c
@@ -99,6 +99,7 @@ void z_refine_output_final( pastix_data_t      *pastix_data,
     (void)tf;
     (void)x;
     (void)gmresx;
+    pastix_data->dparm[DPARM_RELATIVE_ERROR] = err;
 }
 
 /**

--- a/spm/src/spm.c
+++ b/spm/src/spm.c
@@ -293,10 +293,10 @@ spmExit( spmatrix_t *spm )
         free(spm->dofs);
         spm->dofs = NULL;
     }
-/*
-#ifdef PASTIX_WITH_CUDA
+
+/*#ifdef PASTIX_WITH_CUDA
     if(spm->colptrGPU != NULL) {
-		gpu_device_t* gpu_device = (gpu_device_t*)parsec_devices_get(2);
+    gpu_device_t* gpu_device = (gpu_device_t*)parsec_devices_get(2);
 		zone_free( gpu_device->memory, spm->colptrGPU );
         //cudaFree(spm->colptrGPU);
         spm->colptrGPU = NULL;

--- a/spm/src/spm.c
+++ b/spm/src/spm.c
@@ -280,11 +280,11 @@ spmExit( spmatrix_t *spm )
     if(spm->rowPrediction != NULL) {
         free(spm->rowPrediction);
         spm->rowPrediction = NULL;
-    }/*
+    }
     if(spm->values != NULL) {
         free(spm->values);
         spm->values = NULL;
-    }*/
+    }
     if(spm->loc2glob != NULL) {
         free(spm->loc2glob);
         spm->loc2glob = NULL;


### PR DESCRIPTION
This pull request contains bugfixes for:
- memory leak when the spm structure can't be reused (needs CalculiX > 2.17, changes in CalculiX are necessary, BREAKS CalculiX 2.17)
- fixup of the placement of a cuda define
- fixed an integer overflow when the graph is getting too large (consistent with the pastix_int_t now)
- fixed Segmentation fault when the environment variable PASTIX_REFINE_GPU is not set

added feature:
- the relative error of the refinement gets passed back through dparm[DPARM_RELATIVE_ERROR]
