### PR TITLE
Moved GPU usage withing the required #ifdefs

### DIFF
--- a/bcsc/bvec.c
+++ b/bcsc/bvec.c
@@ -21,10 +21,10 @@
 #include <parsec/data_distribution.h>
 #if defined(PASTIX_WITH_CUDA)
 #include <parsec/devices/cuda/dev_cuda.h>
+extern gpu_device_t* gpu_device;
 #endif
 #include "parsec/utils/zone_malloc.h"
 
-extern gpu_device_t* gpu_device;
 extern char* gpu_base;
 
 /**

--- a/refinement/pastix_task_refine.c
+++ b/refinement/pastix_task_refine.c
@@ -35,11 +35,11 @@
 #include <parsec/data_distribution.h>
 #if defined(PASTIX_WITH_CUDA)
 #include <parsec/devices/cuda/dev_cuda.h>
+extern gpu_device_t* gpu_device;
+extern char* gpu_base;
 #endif
 #include "parsec/utils/zone_malloc.h"
 
-extern gpu_device_t* gpu_device;
-extern char* gpu_base;
 
 /**
  *******************************************************************************

--- a/sopalin/pastix_task_solve.c
+++ b/sopalin/pastix_task_solve.c
@@ -31,11 +31,11 @@
 #include <parsec/data_distribution.h>
 #if defined(PASTIX_WITH_CUDA)
 #include <parsec/devices/cuda/dev_cuda.h>
+gpu_device_t* gpu_device = NULL;
+char* gpu_base = NULL;
 #endif
 #include "parsec/utils/zone_malloc.h"
 
-gpu_device_t* gpu_device = NULL;
-char* gpu_base = NULL;
 
 #if defined(PASTIX_DEBUG_SOLVE)
 #include <z_spm.h>

--- a/spm/src/spm.c
+++ b/spm/src/spm.c
@@ -29,9 +29,9 @@
 #include <parsec/data_distribution.h>
 #if defined(PASTIX_WITH_CUDA)
 #include <parsec/devices/cuda/dev_cuda.h>
+#include <cuda_runtime.h>
 #endif
 
-#include <cuda_runtime.h>
 #include <cblas.h>
 #include <lapacke.h>
 


### PR DESCRIPTION
When disabling CUDA, a few compilations arise. After investigation, it seems a few lines where placed outside of the macros checking whether or not CUDA is used. I fixed heuristically (fixing until it compiled) and haven't tested thoroughly the impacts of the change.